### PR TITLE
Fix kd_really_delete root deletion bug, add CI and parallel tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build tests
+      run: make all
+
+    - name: Run tests in parallel
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.exe
+*.o
+out.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+CC = gcc
+CFLAGS = -std=gnu89 -O2 -Wall -Wno-unused-function -Wno-unused-variable \
+         -Wno-unused-but-set-variable -Wno-format -Wno-pointer-to-int-cast \
+         -Wno-int-to-pointer-cast -Wno-implicit-int \
+         -Wno-implicit-function-declaration -Wno-return-type
+LDFLAGS = -lm
+
+# Static linking on Windows to avoid DLL issues
+ifeq ($(OS),Windows_NT)
+  LDFLAGS += -static
+endif
+
+TESTS = kd_test_soft kd_test_hard
+
+.PHONY: all test clean
+
+all: $(TESTS)
+
+kd_test_soft: kd.c kd_test_soft.c kd.h
+	$(CC) $(CFLAGS) -o $@ kd.c kd_test_soft.c $(LDFLAGS)
+
+kd_test_hard: kd.c kd_test_hard.c kd.h
+	$(CC) $(CFLAGS) -o $@ kd.c kd_test_hard.c $(LDFLAGS)
+
+# Run both tests in parallel with exit code checking
+test: $(TESTS)
+	@echo "=== Running tests in parallel ==="
+	@./kd_test_soft$(EXEEXT) & PID1=$$!; \
+	 ./kd_test_hard$(EXEEXT) & PID2=$$!; \
+	 FAIL=0; \
+	 wait $$PID1 || FAIL=1; \
+	 wait $$PID2 || FAIL=1; \
+	 if [ $$FAIL -ne 0 ]; then echo "=== TESTS FAILED ==="; exit 1; fi
+	@echo "=== All tests passed ==="
+
+clean:
+	rm -f kd_test_soft kd_test_hard kd_test_soft.exe kd_test_hard.exe kd_test.exe *.o out.txt

--- a/README.md
+++ b/README.md
@@ -66,13 +66,24 @@ Here are the list of my changes to his code:
 Not all of it is working yet. But, eventually, I'll grab a moment here and there
 to finish it off.
 
+Building
+--------
+
+    make          # build test executables
+    make test     # run soft-delete and hard-delete tests in parallel
+    make clean    # remove build artifacts
+
+Requires gcc. On Ubuntu/Debian: `apt install build-essential`.
+On Windows/MSYS2: `pacman -S mingw-w64-x86_64-gcc`.
+
 TO DO:
 
-1. The really_delete routine seems to have problems with the last delete.
+1. ~~The really_delete routine seems to have problems with the last delete.~~
+   FIXED -- kd_really_delete now handles root-node deletion correctly.
 
 2. The code was part of the OctTools system, and uses other packages,
    like the error stuff (uprintf), and this stuff needs to be cleaned out
-   to reduce the complexity and allow other users to determine what to 
+   to reduce the complexity and allow other users to determine what to
    do on errors.
 
 3. kd_test needs to be upgraded to test every function. Especially the
@@ -81,10 +92,11 @@ TO DO:
 4. Valgrind comes up with all sorts of illegal reads and some illegal
    writes. All are quite mysterious. Need to clean all this up.
 
-5. It would probably be nice to use configure to build from
-   source. Wouldn't it?
+5. ~~It would probably be nice to use configure to build from
+   source. Wouldn't it?~~
+   A Makefile and GitHub Actions CI workflow are now provided.
 
-6. Hey, don't you think that other packages, like GLIB, KDE, GNOME, window 
+6. Hey, don't you think that other packages, like GLIB, KDE, GNOME, window
    managers and systems, anything working in 2d-space, would have a good
    geographic search mechanism built in? Oh, yes, I forgot! There will
    never be more than 32 or 64 objects in use, ever, so why bother?

--- a/kd.c
+++ b/kd.c
@@ -1945,14 +1945,25 @@ kd_status kd_really_delete(kd_tree theTree, kd_generic data, kd_box old_size, in
     elem = find_item(real_tree->tree, 0, data, old_size, 1,0);
     if (elem)
 	{
-		elemdad = path_to_item[path_length-1];
-		/* Delete element */
-		j = KD_DISC(path_length);
-		newelem = kd_do_delete(real_tree,elem,j);
-		if( elemdad->sons[KD_HISON] == elem )
-			elemdad->sons[KD_HISON] = newelem;
+		if (elem == real_tree->tree)
+		{
+			/* Deleting the root node -- path_to_item has no ancestors recorded,
+			   and path_length is stale. Root always has discriminator 0. */
+			j = 0;
+			newelem = kd_do_delete(real_tree, elem, j);
+			real_tree->tree = newelem;
+		}
 		else
-			elemdad->sons[KD_LOSON] = newelem;
+		{
+			elemdad = path_to_item[path_length-1];
+			/* Delete element */
+			j = KD_DISC(path_length);
+			newelem = kd_do_delete(real_tree,elem,j);
+			if( elemdad->sons[KD_HISON] == elem )
+				elemdad->sons[KD_HISON] = newelem;
+			else
+				elemdad->sons[KD_LOSON] = newelem;
+		}
 		FREE(elem);
 		real_tree->item_count--;
 	}

--- a/kd_test.c
+++ b/kd_test.c
@@ -17,7 +17,13 @@
  */
 
 #include "kd.h"
-#include <sys/time.h>
+#include <stdlib.h>
+#include <time.h>
+
+#ifdef _WIN32
+#define random() rand()
+#define srandom(x) srand(x)
+#endif
 
 /* for errtrap */
 char *optProgName = "";
@@ -45,15 +51,10 @@ static void rand_box(kd_box box)
 /* Generates a random box in `box' */
 {
     static int init = 0;
-    long random();
 
     if (!init) {
-	struct timeval tp;
-	struct timezone whocares;
-
 	/* Randomize generator */
-	(void) gettimeofday(&tp, &whocares);
-	(void) srandom((int) (tp.tv_sec + tp.tv_usec));
+	(void) srandom((int) time(NULL));
 	init = 1;
     }
 
@@ -96,12 +97,12 @@ static void gen_boxes(void)
     }
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     kd_tree tree;
     kd_box region, size;
     kd_gen gen;
-    int local[KD_BOXES];
+    static int local[KD_BOXES];
     int idx, i, j, k, n, item;
 
     int s1;

--- a/kd_test_hard.c
+++ b/kd_test_hard.c
@@ -1,0 +1,155 @@
+/*
+ * K-d tree test: hard delete (kd_really_delete)
+ *
+ * Builds a tree of random boxes, verifies search correctness,
+ * then deletes every item using kd_really_delete (structural removal).
+ * Returns 0 on success, non-zero on failure.
+ */
+
+#include "kd.h"
+#include <stdlib.h>
+#include <time.h>
+
+#ifdef _WIN32
+#define random() rand()
+#define srandom(x) srand(x)
+#endif
+
+char *optProgName = "";
+
+#define KD_BOXES	1000000
+#define KD_REGIONS      1000
+
+#define MIN_RANGE	-100000
+#define MAX_RANGE	100000
+#define RANGE_SPAN	(MAX_RANGE - MIN_RANGE + 1)
+#define BOX_RANGE	1000
+
+static kd_box boxes[KD_BOXES];
+
+#define BOXINTERSECT(b1, b2) \
+  (((b1)[KD_RIGHT] >= (b2)[KD_LEFT]) && \
+   ((b2)[KD_RIGHT] >= (b1)[KD_LEFT]) && \
+   ((b1)[KD_TOP] >= (b2)[KD_BOTTOM]) && \
+   ((b2)[KD_TOP] >= (b1)[KD_BOTTOM]))
+
+static void rand_box(kd_box box)
+{
+    static int init = 0;
+
+    if (!init) {
+	(void) srandom((int) time(NULL));
+	init = 1;
+    }
+
+    box[KD_LEFT] = (random() % RANGE_SPAN) + MIN_RANGE;
+    box[KD_BOTTOM] = (random() % RANGE_SPAN) + MIN_RANGE;
+    box[KD_RIGHT] = box[KD_LEFT] + (random() % BOX_RANGE);
+    box[KD_TOP] = box[KD_BOTTOM] + (random() % BOX_RANGE);
+}
+
+static int gen_box(kd_generic arg, kd_generic *val, kd_box size)
+{
+    int *offsetp = ((int *) arg);
+    int offset = *((int *) arg);
+
+    if (offset < KD_BOXES) {
+	*val = (kd_generic) (long)(offset+1);
+	size[KD_LEFT] = boxes[offset][KD_LEFT];
+	size[KD_BOTTOM] = boxes[offset][KD_BOTTOM];
+	size[KD_RIGHT] = boxes[offset][KD_RIGHT];
+	size[KD_TOP] = boxes[offset][KD_TOP];
+	*offsetp += 1;
+	return 1;
+    } else {
+	return 0;
+    }
+}
+
+static void gen_boxes(void)
+{
+    int i;
+    for (i = 0;  i < KD_BOXES;  i++) {
+	rand_box(boxes[i]);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    kd_tree tree;
+    kd_box region, size;
+    kd_gen gen;
+    static int local[KD_BOXES];
+    int idx, i, j, k, n, item;
+    int num_tries, num_del;
+    int tot_tries, tot_dels;
+
+    optProgName = argv[0];
+    gen_boxes();
+    idx = 0;
+    tree = kd_build(gen_box, (kd_generic) &idx);
+
+    kd_badness(tree);
+
+    /* Phase one: search verification */
+    for (i = 0;  i < KD_REGIONS;  i++) {
+	rand_box(region);
+	gen = kd_start(tree, region);
+	n = 0;
+	while (kd_next(gen, (kd_generic *) &(local[n]), size) == KD_OK) {
+	    n++;
+	}
+	kd_finish(gen);
+	if (i%100 == 0) printf("[hard] Region %d: %d boxes found\n", i, n);
+	for (j = 0;  j < KD_BOXES;  j++) {
+	    if (BOXINTERSECT(region, boxes[j])) {
+		for (k = 0;  k < n;  k++) {
+		    if (local[k] == j+1) {
+			local[k] = -1;
+			break;
+		    }
+		}
+		if (k >= n) {
+		    fprintf(stderr, "[hard] FAIL: missing item in search\n");
+		    return 1;
+		}
+	    }
+	}
+	for (k = 0;  k < n;  k++) {
+	    if (local[k] >= 0) {
+		fprintf(stderr, "[hard] FAIL: extra item in search\n");
+		return 1;
+	    }
+	}
+    }
+    printf("[hard] Search verification complete. %d regions searched.\n", KD_REGIONS);
+
+    /* Phase two: hard delete every item */
+    tot_tries = 0;
+    tot_dels = 0;
+    for (i = KD_BOXES-1;  i >= 0;  i--) {
+	if (i%100000==0) printf("[hard] deleting item %d...\n", i);
+	if (kd_really_delete(tree, (kd_generic) (long)(i+1), boxes[i], &num_tries, &num_del) != KD_OK) {
+	    fprintf(stderr, "[hard] FAIL: could not really_delete item %d\n", i);
+	    return 1;
+	}
+	tot_tries += num_tries;
+	tot_dels += num_del;
+    }
+    printf("[hard] Deleted %d items; tries=%d, dels=%d\n", KD_BOXES, tot_tries, tot_dels);
+
+    /* Verify tree is empty */
+    region[KD_LEFT] = MIN_RANGE-1;
+    region[KD_BOTTOM] = MIN_RANGE-1;
+    region[KD_RIGHT] = MAX_RANGE+1;
+    region[KD_TOP] = MAX_RANGE+1;
+    gen = kd_start(tree, region);
+    while (kd_next(gen, (kd_generic *) &item, size) == KD_OK) {
+	fprintf(stderr, "[hard] FAIL: tree not empty after delete\n");
+	return 1;
+    }
+    printf("[hard] Verified tree is empty. PASS\n");
+    kd_destroy(tree, NULL);
+
+    return 0;
+}

--- a/kd_test_soft.c
+++ b/kd_test_soft.c
@@ -1,0 +1,148 @@
+/*
+ * K-d tree test: soft delete (kd_delete)
+ *
+ * Builds a tree of random boxes, verifies search correctness,
+ * then deletes every item using kd_delete (mark-as-deleted).
+ * Returns 0 on success, non-zero on failure.
+ */
+
+#include "kd.h"
+#include <stdlib.h>
+#include <time.h>
+
+#ifdef _WIN32
+#define random() rand()
+#define srandom(x) srand(x)
+#endif
+
+char *optProgName = "";
+
+#define KD_BOXES	1000000
+#define KD_REGIONS      1000
+
+#define MIN_RANGE	-100000
+#define MAX_RANGE	100000
+#define RANGE_SPAN	(MAX_RANGE - MIN_RANGE + 1)
+#define BOX_RANGE	1000
+
+static kd_box boxes[KD_BOXES];
+
+#define BOXINTERSECT(b1, b2) \
+  (((b1)[KD_RIGHT] >= (b2)[KD_LEFT]) && \
+   ((b2)[KD_RIGHT] >= (b1)[KD_LEFT]) && \
+   ((b1)[KD_TOP] >= (b2)[KD_BOTTOM]) && \
+   ((b2)[KD_TOP] >= (b1)[KD_BOTTOM]))
+
+static void rand_box(kd_box box)
+{
+    static int init = 0;
+
+    if (!init) {
+	(void) srandom((int) time(NULL));
+	init = 1;
+    }
+
+    box[KD_LEFT] = (random() % RANGE_SPAN) + MIN_RANGE;
+    box[KD_BOTTOM] = (random() % RANGE_SPAN) + MIN_RANGE;
+    box[KD_RIGHT] = box[KD_LEFT] + (random() % BOX_RANGE);
+    box[KD_TOP] = box[KD_BOTTOM] + (random() % BOX_RANGE);
+}
+
+static int gen_box(kd_generic arg, kd_generic *val, kd_box size)
+{
+    int *offsetp = ((int *) arg);
+    int offset = *((int *) arg);
+
+    if (offset < KD_BOXES) {
+	*val = (kd_generic) (long)(offset+1);
+	size[KD_LEFT] = boxes[offset][KD_LEFT];
+	size[KD_BOTTOM] = boxes[offset][KD_BOTTOM];
+	size[KD_RIGHT] = boxes[offset][KD_RIGHT];
+	size[KD_TOP] = boxes[offset][KD_TOP];
+	*offsetp += 1;
+	return 1;
+    } else {
+	return 0;
+    }
+}
+
+static void gen_boxes(void)
+{
+    int i;
+    for (i = 0;  i < KD_BOXES;  i++) {
+	rand_box(boxes[i]);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    kd_tree tree;
+    kd_box region, size;
+    kd_gen gen;
+    static int local[KD_BOXES];
+    int idx, i, j, k, n, item;
+
+    optProgName = argv[0];
+    gen_boxes();
+    idx = 0;
+    tree = kd_build(gen_box, (kd_generic) &idx);
+
+    kd_badness(tree);
+
+    /* Phase one: search verification */
+    for (i = 0;  i < KD_REGIONS;  i++) {
+	rand_box(region);
+	gen = kd_start(tree, region);
+	n = 0;
+	while (kd_next(gen, (kd_generic *) &(local[n]), size) == KD_OK) {
+	    n++;
+	}
+	kd_finish(gen);
+	if (i%100 == 0) printf("[soft] Region %d: %d boxes found\n", i, n);
+	for (j = 0;  j < KD_BOXES;  j++) {
+	    if (BOXINTERSECT(region, boxes[j])) {
+		for (k = 0;  k < n;  k++) {
+		    if (local[k] == j+1) {
+			local[k] = -1;
+			break;
+		    }
+		}
+		if (k >= n) {
+		    fprintf(stderr, "[soft] FAIL: missing item in search\n");
+		    return 1;
+		}
+	    }
+	}
+	for (k = 0;  k < n;  k++) {
+	    if (local[k] >= 0) {
+		fprintf(stderr, "[soft] FAIL: extra item in search\n");
+		return 1;
+	    }
+	}
+    }
+    printf("[soft] Search verification complete. %d regions searched.\n", KD_REGIONS);
+
+    /* Phase two: soft delete every item */
+    for (i = KD_BOXES-1;  i >= 0;  i--) {
+	if (kd_delete(tree, (kd_generic) (long)(i+1), boxes[i]) != KD_OK) {
+	    fprintf(stderr, "[soft] FAIL: could not delete item %d\n", i);
+	    return 1;
+	}
+    }
+    printf("[soft] Deleted %d items from the tree.\n", KD_BOXES);
+
+    /* Verify tree is empty */
+    region[KD_LEFT] = MIN_RANGE-1;
+    region[KD_BOTTOM] = MIN_RANGE-1;
+    region[KD_RIGHT] = MAX_RANGE+1;
+    region[KD_TOP] = MAX_RANGE+1;
+    gen = kd_start(tree, region);
+    while (kd_next(gen, (kd_generic *) &item, size) == KD_OK) {
+	fprintf(stderr, "[soft] FAIL: tree not empty after delete\n");
+	return 1;
+    }
+    printf("[soft] Verified tree is empty. PASS\n");
+    kd_destroy(tree, NULL);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- **Fix kd_really_delete root node deletion bug** (README TODO #1): When deleting the root node, `find_item()` records no ancestors in `path_to_item[]`, leaving `path_length` stale. This caused `path_to_item[path_length-1]` to read a garbage pointer, `KD_DISC(path_length)` to use the wrong discriminator, and `real_tree->tree` was never updated to the replacement node. Fixed by detecting `elem == real_tree->tree` and handling it directly.
- **Add Makefile** with `make all` / `make test` / `make clean` targets
- **Add GitHub Actions CI** that builds and runs tests on every push/PR
- **Split tests for parallel execution**: `kd_test_soft.c` (soft delete) and `kd_test_hard.c` (hard delete) run independently via `make test`, cutting wall-clock test time roughly in half
- **Fix kd_test.c portability**: replace POSIX `random()`/`gettimeofday()` with `rand()`/`time()`, fix 4MB stack overflow (`local[]` array made static), add `int` return type to `main()`
- **Add .gitignore** for build artifacts
- **Update README** with build instructions, mark TODO #1 as fixed

## Test plan
- [x] `kd_test_soft` passes: 1M items built, 1000 search regions verified, all items soft-deleted, tree verified empty
- [x] `kd_test_hard` passes: 1M items built, 1000 search regions verified, all items hard-deleted (including root), tree verified empty
- [x] Both tests run in parallel via `make test`
- [ ] GitHub Actions CI runs and passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)