### PR TITLE
Fix kd_nearest metric mismatch and wrong initial bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,11 @@ TO DO:
 
 4. Valgrind comes up with all sorts of illegal reads and some illegal
    writes. All are quite mysterious. Need to clean all this up.
-   NOTE: Many valgrind issues were likely caused by the stale path_length
-   bug (fixed in TODO #1) and K&R declaration mismatches (fixed in TODO #2).
+   NOTE: Many issues were caused by the stale path_length bug (fixed in
+   TODO #1), K&R declaration mismatches (fixed in TODO #2), and a metric
+   mismatch in kd_nearest where KDdist returned actual distance but
+   bounds_overlap_ball used squared distance (now fixed -- KDdist uses
+   squared distance internally, converted back to actual at the end).
    Re-run valgrind to see what remains.
 
 5. ~~It would probably be nice to use configure to build from

--- a/kd.c
+++ b/kd.c
@@ -2026,63 +2026,28 @@ typedef struct KDPpriority
 } KDPriority;
 
 
+/*
+ * Returns the SQUARED edge-to-edge distance from query point Xq to the
+ * bounding box of elem.  Using squared distance throughout the nearest-
+ * neighbor search avoids expensive sqrt/hypot calls and keeps the metric
+ * consistent with coord_dist (used by bounds_overlap_ball for pruning).
+ * The final results are converted back to actual distance in kd_neighbor.
+ */
 static double KDdist(kd_box Xq, KDElem *elem)
 {
+	double dx = 0.0, dy = 0.0;
 
-	double hypot();
-	/* The following calcs edge-to-edge distance on bounding boxes. I could
-	   imagine that this would not be good enough for stuff like all-angle
-	   paths. but for totally orthogonal geoms, this would mostly suffice. */
-	if( Xq[KD_LEFT] > elem->size[KD_RIGHT] ) /* off left side */
-	{
-		if(Xq[KD_TOP] < elem->size[KD_BOTTOM]) /* ob2 is in ul quad */
-		{/* dist (Xq[KD_LEFT],Xq[KD_TOP])->(elem->size[KD_BOTTOM,RIGHT])*/
-			return hypot((double)(Xq[KD_LEFT]-elem->size[KD_RIGHT]),
-						 (double)(Xq[KD_TOP]-elem->size[KD_BOTTOM])); 
-		}
-		else if(Xq[KD_BOTTOM] > elem->size[KD_TOP]) /* ob2 is in ll quad */
-		{
-			; /* dist (Xq[KD_LEFT],Xq[KD_BOTTOM])->(elem->size[KD_TOP,RIGHT])*/
-			return hypot((double)(Xq[KD_LEFT]-elem->size[KD_RIGHT]),
-						 (double)(Xq[KD_BOTTOM]-elem->size[KD_TOP])); 
-		}
-		else  /* shadowed to left */
-			return (double)(Xq[KD_LEFT]-elem->size[KD_RIGHT]);
-	}
-	else if (Xq[KD_RIGHT] < elem->size[KD_LEFT])
-	{
-		if(Xq[KD_TOP] < elem->size[KD_BOTTOM]) /* ob2 is in ur quad */
-		{
-			; /* dist (Xq[KD_RIGHT],Xq[KD_TOP])->(elem->size[KD_BOTTOM,LEFT])*/
-			return hypot((double)(Xq[KD_RIGHT]-elem->size[KD_LEFT]),
-						 (double)(Xq[KD_TOP]-elem->size[KD_BOTTOM])); 
-		}
-		else if(Xq[KD_BOTTOM] > elem->size[KD_TOP]) /* ob2 is in lr quad */
-		{
-			; /* dist (Xq[KD_RIGHT],Xq[KD_BOTTOM])->(elem->size[KD_TOP,LEFT])*/
-			return hypot((double)(Xq[KD_RIGHT]-elem->size[KD_LEFT]),
-						 (double)(Xq[KD_BOTTOM]-elem->size[KD_TOP])); 
-		}
-		else  /* shadowed to right */
-			return (double)(elem->size[KD_LEFT]-Xq[KD_RIGHT]);
-	}
+	if( Xq[KD_LEFT] > elem->size[KD_RIGHT] )
+		dx = (double)(Xq[KD_LEFT] - elem->size[KD_RIGHT]);
+	else if( Xq[KD_RIGHT] < elem->size[KD_LEFT] )
+		dx = (double)(elem->size[KD_LEFT] - Xq[KD_RIGHT]);
+
+	if( Xq[KD_BOTTOM] > elem->size[KD_TOP] )
+		dy = (double)(Xq[KD_BOTTOM] - elem->size[KD_TOP]);
 	else if( Xq[KD_TOP] < elem->size[KD_BOTTOM] )
-		return (double)(elem->size[KD_BOTTOM]-Xq[KD_TOP]);
-	else if( Xq[KD_BOTTOM] > elem->size[KD_TOP] )
-		return (double)(Xq[KD_BOTTOM]-elem->size[KD_TOP]);
-	else
-		return 0.0;
-	/*   Well, this is a cheap backup , but pretty simplistic 
-	x1 = (Xq[KD_LEFT] + Xq[KD_RIGHT])/2;
-	y1 = (Xq[KD_BOTTOM] + Xq[KD_TOP])/2;
-	x2 = (elem->size[KD_LEFT] + elem->size[KD_RIGHT])/2;
-	y2 = (elem->size[KD_BOTTOM] + elem->size[KD_TOP])/2;
-	d = (x2-x1);
-	d *= d;
-	d2 = (y2-y1);
-	d2 *= d2;
-	d += d2;
-	return d; */
+		dy = (double)(elem->size[KD_BOTTOM] - Xq[KD_TOP]);
+
+	return dx*dx + dy*dy;
 }
 
 static double coord_dist(long x, long y)
@@ -2327,10 +2292,11 @@ static int  kd_neighbor(KDElem *node, kd_box Xq, int m, KDPriority *list, kd_box
 	}
 	FREE(realGen->stk);
 	FREE(realGen);
-	/* we have to change KDElem * to kd_generic and give the user something back
-	 he can 'identify' with. */
+	/* Convert squared distances back to actual distances, and change
+	   KDElem * to kd_generic for the user's results. */
 	for(p=0;p<m;p++)
 	{
+		list[p].dist = sqrt(list[p].dist);
 		list[p].elem = (KDElem *)list[p].elem->item;
 	}
 	return kd_data_tries;
@@ -2355,7 +2321,7 @@ int kd_nearest(kd_tree tree, int x, int y, int m, kd_priority **alist)
 	for(i=0;i<KD_BOX_MAX;i++)
 	{
 		Bp[i] = MAXINT;
-		Bn[i] = 1<<30;
+		Bn[i] = MININT;
 	}
 	return kd_neighbor(realTree->tree,Xq,m,*list,Bp,Bn);
 }

--- a/kd_test_nearest.c
+++ b/kd_test_nearest.c
@@ -116,20 +116,8 @@ int main(int argc, char **argv)
 
     printf("[nearest] Built tree with %d boxes\n", KD_BOXES);
 
-    /*
-     * Note: kd_nearest has a known metric mismatch between KDdist (which
-     * returns actual distance via hypot) and bounds_overlap_ball (which
-     * uses squared distance via coord_dist). This causes overly aggressive
-     * pruning, so kd_nearest may not always find the true m closest items.
-     * See README TODO #4 for details.
-     *
-     * We test what we can: results should be sorted, the function should
-     * not crash, and it should return reasonable results for most queries.
-     */
-
     /* Test with various neighbor counts */
     for (m = 1; m <= MAX_NEIGHBORS; m *= 2) {
-	int brute_mismatches = 0;
 	for (q = 0; q < NUM_QUERIES; q++) {
 	    int qx = (random() % RANGE_SPAN) + MIN_RANGE;
 	    int qy = (random() % RANGE_SPAN) + MIN_RANGE;
@@ -149,26 +137,23 @@ int main(int argc, char **argv)
 		}
 	    }
 
-	    /* Brute-force comparison (advisory — known metric mismatch) */
+	    /* Brute-force: verify kd_nearest found the true m closest */
 	    for (i = 0; i < KD_BOXES; i++) {
 		brute_dists[i] = box_dist(qx, qy, boxes[i]);
 	    }
 	    qsort(brute_dists, KD_BOXES, sizeof(double), cmp_double);
 
 	    if (list[m-1].dist > brute_dists[m-1] + 1e-6) {
-		brute_mismatches++;
+		fprintf(stderr, "[nearest] FAIL: kd_nearest missed closer item at m=%d q=%d "
+			"(kd furthest=%g, brute m-th=%g)\n",
+			m, q, list[m-1].dist, brute_dists[m-1]);
+		free(list);
+		return 1;
 	    }
 
 	    free(list);
 	}
-	if (brute_mismatches > 0) {
-	    printf("[nearest] m=%d: %d queries, %d had suboptimal results "
-		   "(known metric mismatch in bounds_overlap_ball)\n",
-		   m, NUM_QUERIES, brute_mismatches);
-	} else {
-	    printf("[nearest] m=%d: %d queries passed (exact match with brute force)\n",
-		   m, NUM_QUERIES);
-	}
+	printf("[nearest] m=%d: %d queries passed\n", m, NUM_QUERIES);
     }
 
     /* Edge case: query point inside a box (distance should be 0) */
@@ -178,12 +163,13 @@ int main(int argc, char **argv)
 	int visited = kd_nearest(tree, qx, qy, 1, &list);
 	(void)visited;
 	if (list[0].dist > 1e-9) {
-	    printf("[nearest] Edge case (point inside box): nearest dist=%g "
-		   "(expected 0, known metric mismatch)\n", list[0].dist);
-	} else {
-	    printf("[nearest] Edge case (point inside box): PASS\n");
+	    fprintf(stderr, "[nearest] FAIL: query inside box[0] but nearest dist=%g\n",
+		    list[0].dist);
+	    free(list);
+	    return 1;
 	}
 	free(list);
+	printf("[nearest] Edge case (point inside box): PASS\n");
     }
 
     printf("[nearest] All tests passed. PASS\n");


### PR DESCRIPTION
## Summary
Two bugs in the nearest-neighbor search caused it to miss closer items:

1. **Metric mismatch**: `KDdist` returned actual distance (via `hypot`) but `bounds_overlap_ball` used squared distance (via `coord_dist`). The comparison `sum > list[m-1].dist` compared squared vs actual, causing overly aggressive subtree pruning. Fixed by making `KDdist` return squared distance internally; results converted back via `sqrt` at the end of `kd_neighbor`.

2. **Wrong initial bounds**: `kd_nearest` initialized `Bn[i] = 1<<30` (~1 billion), but `Bn` represents the lower bound of the search region and should be `MININT`. The large positive value caused `bounds_overlap_ball` to compute huge spurious distances, pruning almost all subtrees on the first check.

Also: `KDdist` is now simpler (no `hypot` call, just `dx*dx + dy*dy`) and slightly faster.

## Test plan
- [x] `kd_test_nearest` passes with **strict** brute-force verification: 500/500 queries exact-match across m=1,2,4,8,16
- [x] Edge case (query inside box) returns distance 0
- [x] `kd_test_soft` and `kd_test_hard` still pass
- [ ] GitHub Actions CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)