### PR TITLE
build: Add Makefiles for 64-bit language translations

### DIFF
--- a/coord64/go/Makefile
+++ b/coord64/go/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all build test clean
+
+all: test
+
+build:
+	go build -v ./...
+
+test:
+	go test -v ./...
+
+clean:
+	go clean

--- a/coord64/julia/Makefile
+++ b/coord64/julia/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all test clean
+
+all: test
+
+test:
+	julia kd_test.jl
+
+clean:
+	@echo "Cleaning Julia temporary files..."
+	rm -f *.cov
+	rm -f *~

--- a/coord64/rust/Makefile
+++ b/coord64/rust/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all build test clean
+
+all: test
+
+build:
+	cargo build --release
+
+test:
+	cargo test --release -- --nocapture
+
+clean:
+	cargo clean


### PR DESCRIPTION
- Added standard Makefiles for Go, Rust, and Julia in their coord64 dirs.
- Unified developer experience with standard `make test` and `make clean` targets.
- Pre-configured Rust target for --release mode testing.